### PR TITLE
Enemy Damage Indicator + Bat Fix

### DIFF
--- a/Assets/Animation/bat_1.controller
+++ b/Assets/Animation/bat_1.controller
@@ -1,5 +1,102 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-8691357428696033608
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: bat 0
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 2b2d71f54133a3244a47073b26fbed3a, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-7077705819056115625
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New State 0
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-5304875382434903788
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New State
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &-2785269812383170458
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New StateMachine
+  m_ChildStates: []
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 0}
 --- !u!1102 &-1057826532932842184
 AnimatorState:
   serializedVersion: 6
@@ -34,7 +131,13 @@ AnimatorController:
   m_PrefabAsset: {fileID: 0}
   m_Name: bat_1
   serializedVersion: 5
-  m_AnimatorParameters: []
+  m_AnimatorParameters:
+  - m_Name: isDead
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -60,7 +163,22 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -1057826532932842184}
     m_Position: {x: 200, y: 0, z: 0}
-  m_ChildStateMachines: []
+  - serializedVersion: 1
+    m_State: {fileID: -5304875382434903788}
+    m_Position: {x: 429.84198, y: 70.39064, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -7077705819056115625}
+    m_Position: {x: 270, y: -520, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -8691357428696033608}
+    m_Position: {x: 136.90619, y: -494.68262, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 8794451059412477338}
+    m_Position: {x: 245.4275, y: -502.08075, z: 0}
+  m_ChildStateMachines:
+  - serializedVersion: 1
+    m_StateMachine: {fileID: -2785269812383170458}
+    m_Position: {x: 243.47467, y: -16.475494, z: 0}
   m_AnyStateTransitions: []
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
@@ -70,3 +188,29 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -1057826532932842184}
+--- !u!1102 &8794451059412477338
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: bat 1
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 2b2d71f54133a3244a47073b26fbed3a, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/Prefabs/bat_1.prefab
+++ b/Assets/Prefabs/bat_1.prefab
@@ -130,7 +130,7 @@ GameObject:
   - component: {fileID: 6257651749798134504}
   - component: {fileID: 6257651749798134502}
   - component: {fileID: 1747623164}
-  - component: {fileID: 7460150199328366177}
+  - component: {fileID: 1898902284}
   m_Layer: 0
   m_Name: bat_1
   m_TagString: BatEnemy
@@ -311,29 +311,15 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!61 &7460150199328366177
-BoxCollider2D:
+--- !u!114 &1898902284
+MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6257651749798134508}
-  m_Enabled: 0
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.16, y: 0.12}
-    newSize: {x: 0.16, y: 0.12}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.16, y: 0.12}
-  m_EdgeRadius: 0
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6e70db853e9e542b6885fee8a49d999c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -29023,6 +29023,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6257651749798134507, guid: d53953a8d5bd44984b2d8c4674f517a0, type: 3}
+      propertyPath: maxLives
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6257651749798134507, guid: d53953a8d5bd44984b2d8c4674f517a0, type: 3}
       propertyPath: playerTransform
       value: 
       objectReference: {fileID: 1917396527}
@@ -29030,6 +29034,5 @@ PrefabInstance:
       propertyPath: m_Name
       value: bat_1
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 7460150199328366177, guid: d53953a8d5bd44984b2d8c4674f517a0, type: 3}
+    m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d53953a8d5bd44984b2d8c4674f517a0, type: 3}

--- a/Assets/Scripts/Bat.cs
+++ b/Assets/Scripts/Bat.cs
@@ -17,13 +17,15 @@ public class Bat : MonoBehaviour
     public float maxLives = 3f;
     public Renderer renderer;
     Transform glassShield;
-
-    
+    private ShowDamage damageScript;
+    private Animator animator;
 
     private void Awake()
     {
         rb = GetComponent<Rigidbody2D>();
         health = maxLives;
+        damageScript = GetComponent<ShowDamage>();
+        animator = GetComponent<Animator>();
     }
 
     private void Start()
@@ -103,6 +105,7 @@ public class Bat : MonoBehaviour
             {
                 health -= damage;
                 print(health);
+                damageScript.TurnRed();
             }
             if (health <=0)
             {
@@ -114,6 +117,7 @@ public class Bat : MonoBehaviour
                 rb.velocity = new Vector2(0f, 0f);
                 Color color = HexToColor("372E2E");
                 renderer.material.color = color;
+                animator.enabled = false;
             }
         }
     }

--- a/Assets/Scripts/ShowDamage.cs
+++ b/Assets/Scripts/ShowDamage.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ShowDamage : MonoBehaviour
+{
+    private SpriteRenderer spriteRenderer;
+    private Color originalColor;
+
+    void Start()
+    {
+        spriteRenderer = GetComponent<SpriteRenderer>();
+        originalColor = spriteRenderer.color;
+    }
+
+    public void TurnRed()
+    {
+        StartCoroutine(ChangeColorTemporarily());
+    }
+
+    IEnumerator ChangeColorTemporarily()
+    {
+        print("turn red");
+        spriteRenderer.color = Color.red;
+        yield return new WaitForSeconds(1.0f); 
+        spriteRenderer.color = originalColor;
+    }
+}
+

--- a/Assets/Scripts/ShowDamage.cs.meta
+++ b/Assets/Scripts/ShowDamage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e70db853e9e542b6885fee8a49d999c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Enemies with multiple lives now turn red for a second to indicate they take damage (I temporarily made on of the bats have 3 lives to demonstrate how this works)
- Bat enemy does not animate once its dead