### PR TITLE
Level 2 Bug Fixes

### DIFF
--- a/Assets/Scenes/Level 2.unity
+++ b/Assets/Scenes/Level 2.unity
@@ -17828,7 +17828,7 @@ PrefabInstance:
     - target: {fileID: 1917396530, guid: 27bf31f6833d5b742a6b7841e983dd6b, type: 3}
       propertyPath: messageToPlayer
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 100613700}
     - target: {fileID: 1917396533, guid: 27bf31f6833d5b742a6b7841e983dd6b, type: 3}
       propertyPath: glueForm
       value: 

--- a/Assets/Scripts/Scene and UI/RoomSwitch.cs
+++ b/Assets/Scripts/Scene and UI/RoomSwitch.cs
@@ -30,8 +30,11 @@ public class RoomSwitch : MonoBehaviour {
             cam.minPosition += cameraChange;
             cam.maxPosition += cameraChange;
             other.transform.position += playerChange;
-            Banner.SetActive(true);
-            Time.timeScale = 0;
+            if (Banner != null)
+            {
+	            Banner.SetActive(true);
+	            Time.timeScale = 0;
+            }
         }
     }
 


### PR DESCRIPTION
- Fixed bug where player wouldn't die in level 2 if they had 0 health
- Fixed error in level 2 saying that banner object wasn't set to reference ( added conditional checking for case of null)