### PR TITLE
Pause Menu + Death Screen Improvements

### DIFF
--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -14,6 +15,7 @@ public class PlayerController : MonoBehaviour
     public bool isBat;
     private GameObject enemy;
     private Level2_Rock rockEnemy;
+    public PauseMenuController pmc;
     // Start is called before the first frame update
     void Start()
     {
@@ -43,8 +45,11 @@ public class PlayerController : MonoBehaviour
             TakeDamage(3f, "SpinningHazard");
         }
     }
-    
-    
+
+    void Update()
+    {
+
+    }
 
     public void TakeDamage(float damage, string enemy)
     {
@@ -74,6 +79,7 @@ public class PlayerController : MonoBehaviour
             if (health <= 0)
             {
                 messageToPlayer.DisplayDied();
+                pmc.isDead = true;
                 Vector2 playerposition = transform.position;
                 sendtogoogle.Send(System.DateTime.Now, playerposition, enemy);
                 gameObject.SetActive(false);

--- a/Assets/Scripts/Scene and UI/MessageToPlayer.cs
+++ b/Assets/Scripts/Scene and UI/MessageToPlayer.cs
@@ -48,7 +48,7 @@ public class MessageToPlayer : MonoBehaviour
     public void DisplayDied()
     {
         Debug.Log("player died");
-        textMeshProUI.text = "You died\nPress Esc";
+        textMeshProUI.text = "You died\nPress R to Restart\nPress P for pause menu";
         //Invoke("Clear", 3f);
     }
 

--- a/Assets/Scripts/Scene and UI/PauseMenuController.cs
+++ b/Assets/Scripts/Scene and UI/PauseMenuController.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -5,10 +6,16 @@ public class PauseMenuController : MonoBehaviour
 {
     public GameObject pauseMenuUI; // Attach your Pause Menu UI to this in inspector
     public GameObject pausePanel; // Attach your Pause Panel to this in inspector
+    public bool isDead;
+
+    private void Start()
+    {
+        isDead = false;
+    }
 
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Escape))
+        if (Input.GetKeyDown(KeyCode.P))
         {
             if (Time.timeScale == 1)
             {
@@ -20,6 +27,11 @@ public class PauseMenuController : MonoBehaviour
             {
                 Resume();
             }
+        }
+        
+        if (isDead && Input.GetKeyDown(KeyCode.R))
+        {
+            RestartLevel();
         }
     }
 

--- a/Assets/Scripts/SendToGoogle.cs
+++ b/Assets/Scripts/SendToGoogle.cs
@@ -13,7 +13,7 @@ public class SendToGoogle : MonoBehaviour
     private DateTime startTime;
     private AbilityManager abilityManager;
     private float nextActionTime = 0.0f;
-    private float period = 1.0f; // Ãë
+    private float period = 1.0f; // ï¿½ï¿½
     private PlayerController playcontroller;
     private Dictionary<float, Vector2> positionData = new Dictionary<float, Vector2>();
     private Dictionary<float, String> abilityData = new Dictionary<float, String>();

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.ide.rider": "3.0.21",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
+    "com.unity.jobs": "0.70.0-preview.7",
     "com.unity.render-pipelines.universal": "12.1.11",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -101,6 +101,17 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.collections": {
+      "version": "1.4.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.burst": "1.6.6",
+        "com.unity.nuget.mono-cecil": "1.11.4",
+        "com.unity.test-framework": "1.1.31"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ext.nunit": {
       "version": "1.0.6",
       "depth": 1,
@@ -147,9 +158,25 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.jobs": {
+      "version": "0.70.0-preview.7",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.collections": "1.4.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.mathematics": {
       "version": "1.2.6",
       "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.nuget.mono-cecil": {
+      "version": "1.11.4",
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"


### PR DESCRIPTION
- Use P instead of ESC now to go to pause menu (makes it so you can pause in full screen mode)
- If the player dies they can now simply press R to restart the level instead of having to go into pause menu
- Changed message to player to explain this to the player